### PR TITLE
Truly shutdowns the embedded driver.

### DIFF
--- a/src/main/java/org/carlspring/maven/derby/AbstractDerbyMojo.java
+++ b/src/main/java/org/carlspring/maven/derby/AbstractDerbyMojo.java
@@ -72,7 +72,7 @@ public abstract class AbstractDerbyMojo
     /**
      * The username to use when shutting down the database.
      */
-    @Parameter(property = "derby.url.shutdown")
+    @Parameter(property = "derby.url.shutdown", defaultValue="jdbc:derby:;shutdown=true")
     String connectionURLShutdown;
 
     /**

--- a/src/main/java/org/carlspring/maven/derby/StopDerbyMojo.java
+++ b/src/main/java/org/carlspring/maven/derby/StopDerbyMojo.java
@@ -62,7 +62,7 @@ public class StopDerbyMojo
 
             try
             {
-                DriverManager.getConnection("jdbc:derby:;shutdown=true");
+                DriverManager.getConnection(getConnectionURLShutdown());
             }
             catch (SQLException e)
             {


### PR DESCRIPTION
at least in my template project, getConnectionURL() is not set.
The call to
DriverManager.getConnection(getConnectionURL());
throws an NPE and the call to
DriverManager.getConnection("jdbc:derby:;shutdown=true");
never happens, leaving the driver active in the JVM.
