### PR TITLE
Add a configuration "skip" (mapped to "derby.skip")

### DIFF
--- a/USAGE
+++ b/USAGE
@@ -69,3 +69,14 @@ Usage of the run goal, configure the plugin outside of the "execution" scope as 
 
     # mvn derby:stop
     Sends a stop message to the configured server instance.
+
+The maven property derby.skip, if set to true, will prevent the plugin from launching derby. It can also be set with
+    <plugin>
+        <groupId>org.carlspring.maven</groupId>
+        <artifactId>derby-maven-plugin</artifactId>
+        <version>${version.derby.plugin}</version>
+        <configuration>
+            <skip>true</skip>
+        </configuration>
+        ...
+     </plugin>

--- a/src/main/java/org/carlspring/maven/derby/AbstractDerbyMojo.java
+++ b/src/main/java/org/carlspring/maven/derby/AbstractDerbyMojo.java
@@ -88,6 +88,12 @@ public abstract class AbstractDerbyMojo
     boolean debugStatements;
 
     /**
+     * Whether to bypass running Derby.
+     */
+    @Parameter(property = "derby.skip")
+    boolean skip;
+
+    /**
      * Shared {@link NetworkServerControl} instance for all mojos.
      */
     protected NetworkServerControl server;
@@ -104,6 +110,12 @@ public abstract class AbstractDerbyMojo
     public void execute()
             throws MojoExecutionException, MojoFailureException
     {
+        if ( skip )
+        {
+            getLog().info("Skipping Derby execution");
+            return;
+        }
+
         setupDerby();
 
         doExecute();
@@ -238,5 +250,16 @@ public abstract class AbstractDerbyMojo
     {
         this.debugStatements = debugStatements;
     }
+
+    public boolean isSkip()
+    {
+        return skip;
+    }
+
+    public void setSkip(boolean skip)
+    {
+        this.skip = skip;
+    }
+
 
 }

--- a/src/test/java/org/carlspring/maven/derby/AbstractDerbyMojoTest.java
+++ b/src/test/java/org/carlspring/maven/derby/AbstractDerbyMojoTest.java
@@ -1,5 +1,8 @@
 package org.carlspring.maven.derby;
 
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 
 /**
@@ -22,4 +25,9 @@ public abstract class AbstractDerbyMojoTest
         mojo.setPassword("derby");
     }
 
+    protected boolean isDerbyUp(AbstractDerbyMojo mojo)
+            throws SQLException
+    {
+        return DriverManager.getConnection(mojo.getConnectionURL() + ";create=true").isReadOnly();
+    }
 }

--- a/src/test/java/org/carlspring/maven/derby/RunDerbyMojoTest.java
+++ b/src/test/java/org/carlspring/maven/derby/RunDerbyMojoTest.java
@@ -16,6 +16,10 @@ package org.carlspring.maven.derby;
  * limitations under the License.
  */
 
+import java.sql.SQLException;
+
+import org.junit.Assert;
+
 /**
  * @author Jason Stiefel (jason@stiefel.io)
  */
@@ -49,6 +53,8 @@ public class RunDerbyMojoTest
         rt.start();
 
         Thread.sleep(3000);
+        Assert.assertFalse(runMojo.isSkip());
+        Assert.assertFalse(isDerbyUp(runMojo));
 
         System.out.println("Stopping the server ...");
         stopMojo.execute();
@@ -57,6 +63,35 @@ public class RunDerbyMojoTest
         assertTrue("Running thread does not report ended.", rt.ended);
         assertFalse(rt.isAlive());
 
+    }
+
+    public void testSkipMojo()
+            throws Exception
+    {
+        runMojo.setSkip(true);
+
+        RunningThread rt = new RunningThread(runMojo);
+        System.out.println("Starting the run thread ...");
+        rt.start();
+
+        Thread.sleep(3000);
+        Assert.assertTrue(runMojo.isSkip());
+        try
+        {
+            isDerbyUp(runMojo);
+            System.out.println("Stopping the server ...");
+            stopMojo.execute();
+
+            Thread.sleep(3000);
+            assertTrue("Running thread does not report ended.", rt.ended);
+            assertFalse(rt.isAlive());
+
+            Assert.fail("Derby should not have been started.");
+        }
+        catch (SQLException ignored)
+        {
+
+        }
     }
 
     class RunningThread extends Thread

--- a/src/test/java/org/carlspring/maven/derby/StartDerbyMojoTest.java
+++ b/src/test/java/org/carlspring/maven/derby/StartDerbyMojoTest.java
@@ -16,8 +16,11 @@ package org.carlspring.maven.derby;
  * limitations under the License.
  */
 
+import java.sql.SQLException;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.junit.Assert;
 
 /**
  * @author mtodorov
@@ -43,13 +46,38 @@ public class StartDerbyMojoTest
     }
 
     public void testMojo()
-            throws MojoExecutionException, MojoFailureException, InterruptedException
+            throws MojoExecutionException, MojoFailureException, InterruptedException, SQLException
     {
         startMojo.execute();
+        Assert.assertFalse(startMojo.isSkip());
+        Assert.assertFalse(isDerbyUp(startMojo));
 
         Thread.sleep(5000);
 
         stopMojo.execute();
+    }
+
+    public void testSkipMojo()
+            throws MojoExecutionException, MojoFailureException, InterruptedException
+    {
+        startMojo.setSkip(true);
+
+        startMojo.execute();
+        Assert.assertTrue(startMojo.isSkip());
+        try
+        {
+            isDerbyUp(startMojo);
+
+            Thread.sleep(5000);
+
+            stopMojo.execute();
+
+            Assert.fail("Derby should not have been started.");
+        }
+        catch(SQLException ignored)
+        {
+
+        }
     }
 
 }


### PR DESCRIPTION
This is very handy to skip starting/stopping derby when a particular build is already skipping integration tests
