### PR TITLE
for discussion: speedup derby shutdown

### DIFF
--- a/src/main/java/org/carlspring/maven/derby/StopDerbyMojo.java
+++ b/src/main/java/org/carlspring/maven/derby/StopDerbyMojo.java
@@ -87,10 +87,10 @@ public class StopDerbyMojo
             // TODO: - investigate - isn't this done by server.shutdown() already?
             while (true)
             {
-                Thread.sleep(1000);
                 try
                 {
                     server.ping();
+                    Thread.sleep(1000);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
This is about the verification loop https://github.com/carlspring/derby-maven-plugin/blob/master/src/main/java/org/carlspring/maven/derby/StopDerbyMojo.java#L87

I think the whole loop could be removed, as indicated in the comment.
But I'm not familiar with the design choices that led to the current solution, so I'd like to propose this change as a compromise: move the delay behind the verification step in order to avoid the mandatory 1 second delay after shutdown.

I'd also be perfectly happy if you choose to reject this PR and instead decide to remove the loop.
