### PR TITLE
Refactored tests

### DIFF
--- a/src/test/java/org/carlspring/maven/derby/AbstractDerbyMojoTest.java
+++ b/src/test/java/org/carlspring/maven/derby/AbstractDerbyMojoTest.java
@@ -11,6 +11,7 @@ import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingRequest;
+import org.junit.Assert;
 
 /**
  * @author Jason Stiefel (jason@stiefel.io)
@@ -21,8 +22,16 @@ public abstract class AbstractDerbyMojoTest
         extends AbstractMojoTestCase
 {
 
+    /**
+     * The JDBC connection URL for a local Derby server on the default port
+     */
+    private static final String LOCAL_DERBY_URL = "jdbc:derby://localhost:1527/db;user=derby;password=derby;create=true";
     protected static final String TARGET_TEST_CLASSES = "target/test-classes";
     protected static final String POM_PLUGIN = TARGET_TEST_CLASSES + "/poms/pom-start.xml";
+    /**
+     * A delay sufficiently long for Derby startup and shutdown operations to complete.
+     */
+    protected static final long CONNECTION_DELAY = 3000;
 
     protected Mojo lookupConfiguredMojo(String goal, String basedir)
             throws Exception
@@ -42,10 +51,33 @@ public abstract class AbstractDerbyMojoTest
         return project;
     }
 
-    protected boolean isDerbyUp(AbstractDerbyMojo mojo)
+    /**
+     * Asserts that the Derby server is up.
+     * 
+     * @throws AssertionError if no connection can be established.
+     */
+    protected static void assertDerbyIsUp()
+            throws AssertionError
+    {
+        try
+        {
+            connectToDerby();
+        }
+        catch (SQLException e)
+        {
+            Assert.fail("Derby is not up.");
+        }
+    }
+
+    /**
+     * Connects to the local Derby server.
+     * 
+     * @throws SQLException if no connection can be established
+     */
+    protected static void connectToDerby()
             throws SQLException
     {
-        return DriverManager.getConnection("jdbc:derby://localhost:1527/db;user=derby;password=derby;create=true").isReadOnly();
+        DriverManager.getConnection(LOCAL_DERBY_URL).isReadOnly();
     }
 
 }

--- a/src/test/java/org/carlspring/maven/derby/StartDerbyMojoTest.java
+++ b/src/test/java/org/carlspring/maven/derby/StartDerbyMojoTest.java
@@ -44,39 +44,46 @@ public class StartDerbyMojoTest
         stopMojo = (StopDerbyMojo) lookupConfiguredMojo("stop", POM_PLUGIN);
     }
 
-    public void testMojo()
+    public void testMojoDefaultSettings()
+    {
+        Assert.assertFalse(startMojo.isSkip());
+    }
+    
+    public void testNormalExecution()
             throws MojoExecutionException, MojoFailureException, InterruptedException, SQLException
     {
         startMojo.execute();
-        Assert.assertFalse(startMojo.isSkip());
-        Assert.assertFalse(isDerbyUp(startMojo));
+        Thread.sleep(CONNECTION_DELAY);
 
-        Thread.sleep(5000);
+        assertDerbyIsUp();
 
-        stopMojo.execute();
+        shutdownDerby();
     }
 
-    public void testSkipMojo()
+    public void testSkipOption()
             throws MojoExecutionException, MojoFailureException, InterruptedException
     {
         startMojo.setSkip(true);
 
         startMojo.execute();
-        Assert.assertTrue(startMojo.isSkip());
+        Thread.sleep(CONNECTION_DELAY);
+
         try
         {
-            isDerbyUp(startMojo);
+            connectToDerby();  // should fail because Derby startup is skipped
 
-            Thread.sleep(5000);
-
-            stopMojo.execute();
-
+            shutdownDerby();
             Assert.fail("Derby should not have been started.");
         }
         catch(SQLException ignored)
         {
-
+            // expected
         }
+    }
+
+    private void shutdownDerby() 
+            throws InterruptedException, MojoExecutionException, MojoFailureException {
+        stopMojo.execute();
     }
 
 }


### PR DESCRIPTION
There was a very confusing idiom for verifying whether Derby was up or
not: Assert.assertFalse(isDerbyUp(startMojo)),
where a false value for isDerbyUp meant that Derby was up and an
SQLException being thrown meant that it was not.

This refactoring focuses the tests on normal vs. skipped execution.

Signed-off-by: Harald Albers <github@albersweb.de>